### PR TITLE
add authentication to install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,17 @@
       <a class="Header-github" href="https://github.com/duojs/duo">View on GitHub</a>
     </header>
     <main>
-      <article><h2 id="getting-started">Getting Started</h2>
-<p>Duo is a next-generation package manager that blends the best ideas from <a href="https://github.com/component/component">Component</a>, <a href="https://github.com/substack/node-browserify">Browserify</a> and <a href="http://go-lang.com/">Go</a> to make organizing and writing front-end code quick and painless.</p>
-<p>Install Duo straight from npm with:</p>
+      <article><p>Duo is a next-generation package manager that blends the best ideas from <a href="https://github.com/component/component">Component</a>, <a href="https://github.com/substack/node-browserify">Browserify</a> and <a href="http://go-lang.com/">Go</a> to make organizing and writing front-end code quick and painless.</p>
+<h2 id="install-it">Install It</h2>
+<p>Install Duo straight from <code>npm</code> with:</p>
 <pre><code>$ npm install -g duo
-</code></pre><p>To get started just write normal Javascript, requiring dependencies straight from the file system or from GitHub as you need them:</p>
+</code></pre><p>Duo requires you to authenticate with GitHub to increase your rate limit and allow you to pull from private repositories. To do that, add the following entry to your <code>~/.netrc</code> file:</p>
+<pre><code>machine api.github.com
+  login &lt;username&gt;
+  password &lt;token&gt;
+</code></pre><p>You can quickly create a new GitHub <code>token</code> <a href="https://github.com/settings/tokens/new">here</a>. </p>
+<h2 id="getting-started">Getting Started</h2>
+<p>To get started just write normal Javascript, requiring dependencies straight from the file system or from GitHub as you need them:</p>
 <pre><code class="lang-js">var uid = require(&#39;matthewmueller/uid&#39;);
 var fmt = require(&#39;yields/fmt&#39;);
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ var fmt = require(&#39;yields/fmt&#39;);
 var msg = fmt(&#39;Your unique ID is %s!&#39;, uid());
 window.alert(msg);
 </code></pre>
+<p>That <code>matthewmueller/uid</code> will pull the dependencies <a href="https://github.com/matthewmueller/uid">straight from GitHub</a>, without you needing to edit any package manifest file!</p>
 <p>Then use <code>duo</code> to install your dependencies and build your file:</p>
 <pre><code>$ duo index.js &gt; build.js
 </code></pre><p>Finally, drop a single <code>&lt;script&gt;</code> onto your page and you’re done!</p>

--- a/src/index.md
+++ b/src/index.md
@@ -1,14 +1,25 @@
 
-
-## Getting Started
-
 Duo is a next-generation package manager that blends the best ideas from [Component](https://github.com/component/component), [Browserify](https://github.com/substack/node-browserify) and [Go](http://go-lang.com/) to make organizing and writing front-end code quick and painless.
 
-Install Duo straight from npm with:
+
+## Install It
+
+Install Duo straight from `npm` with:
 
 ```
 $ npm install -g duo
 ```
+
+Duo requires you to authenticate with GitHub to increase your rate limit and allow you to pull from private repositories. To do that, add the following entry to your `~/.netrc` file:
+
+    machine api.github.com
+      login <username>
+      password <token>
+
+You can quickly create a new GitHub `token` [here](https://github.com/settings/tokens/new). 
+
+
+## Getting Started
 
 To get started just write normal Javascript, requiring dependencies straight from the file system or from GitHub as you need them:
 

--- a/src/index.md
+++ b/src/index.md
@@ -31,6 +31,8 @@ var msg = fmt('Your unique ID is %s!', uid());
 window.alert(msg);
 ```
 
+That `matthewmueller/uid` will pull the dependency [straight from GitHub](https://github.com/matthewmueller/uid), without you needing to edit any package manifest file!
+
 Then use `duo` to install your dependencies and build your file:
 
 ```


### PR DESCRIPTION
Ends up looking like this for now:

![](https://i.cloudup.com/4h7TGol2_J.png)

Once we make it optional we can remove this, since it is a somewhat large setup barrier to just trying it out for people I think.
