### PR TITLE
Correct link to browserify tag on NPM

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ var schema = require(&#39;./schema.json&#39;);
 <pre><code>$ duo in.js &gt; out.js
 $ duo in.css &gt; out.css
 </code></pre><h2 id="ii-components">II. Components</h2>
-<p>A successful package manager needs to have a strong component ecosystem. Duo supports all of the existing <a href="https://github.com/component/component/wiki/Components">Component packages</a> out of the box. And, since Duo can load from paths, it supports all <a href="http://bower.io/search/">Bower packages</a> too. <em>There are even plans to support <a href="https://www.npmjs.org/browse/keyword/browser">Browserify packages</a> as well.</em></p>
+<p>A successful package manager needs to have a strong component ecosystem. Duo supports all of the existing <a href="https://github.com/component/component/wiki/Components">Component packages</a> out of the box. And, since Duo can load from paths, it supports all <a href="http://bower.io/search/">Bower packages</a> too. <em>There are even plans to support <a href="https://www.npmjs.org/browse/keyword/browserify">Browserify packages</a> as well.</em></p>
 <p>We’re hoping to bridge the gap between all the different package managers and come up with a solution that works for everyone.</p>
 <p>To create your own public component, just add a <code>component.json</code> to your repository:</p>
 <pre><code class="lang-json">{


### PR DESCRIPTION
Was previously pointing to the `browser` tag, rather than `browserify` which contains the packages one would be interested in.
