### PR TITLE
Fix black bars in Firefox and Safari

### DIFF
--- a/build/index.css
+++ b/build/index.css
@@ -681,8 +681,8 @@ p > code {
   right: 0;
   top: 0;
   height: 100px;
-  background: -webkit-linear-gradient(bottom, transparent, #FEFFF8);
-  background: linear-gradient(to top, transparent, #FEFFF8);
+  background: -webkit-linear-gradient(bottom, rgba(254, 255, 248, 0), #FEFFF8);
+  background: linear-gradient(to top, rgba(254, 255, 248, 0), #FEFFF8);
 }
 
 .Footer p {
@@ -790,8 +790,8 @@ p > code {
   right: 0;
   bottom: 0;
   height: 100px;
-  background: -webkit-linear-gradient(top, transparent, #FEFFF8);
-  background: linear-gradient(to bottom, transparent, #FEFFF8);
+  background: -webkit-linear-gradient(top, rgba(254, 255, 248, 0), #FEFFF8);
+  background: linear-gradient(to bottom, rgba(254, 255, 248, 0), #FEFFF8);
 }
 
 /**

--- a/lib/footer/index.css
+++ b/lib/footer/index.css
@@ -28,7 +28,7 @@
   right: 0;
   top: 0;
   height: 100px;
-  background: linear-gradient(to top, transparent, var(--white));
+  background: linear-gradient(to top, color(var(--white) alpha(0%)), var(--white));
 }
 
 .Footer p {

--- a/lib/header/index.css
+++ b/lib/header/index.css
@@ -33,7 +33,7 @@
   right: 0;
   bottom: 0;
   height: 100px;
-  background: linear-gradient(to bottom, transparent, var(--white));
+  background: linear-gradient(to bottom, color(var(--white) alpha(0%)), var(--white));
 }
 
 /**


### PR DESCRIPTION
`linear-gradient` (mistakenly) treats `transparent` as `rgba(0, 0, 0, 0)` and ugly gradients result.
