### PR TITLE
using duo-serve instead of a custom koa server

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,23 +1,28 @@
 #!/usr/bin/env node
 
 var chalk = require('chalk');
-var e = require('co-exec');
 var fmt = require('util').format;
-var koa = require('koa');
-var logger = require('koa-logger');
-var serve = require('koa-static');
-var join = require('path').join;
-var root = join(__dirname, '..');
+var serve = require('duo-serve');
+var myth = require('myth');
+var path = require('path');
+var root = path.resolve(__dirname, '..');
 
 /**
  * Make a server that serves the static build and rebuilds on every request.
  */
 
 var port = 8888;
-var server = koa()
-  .use(logger())
-  .use(exec('make build'))
-  .use(serve(root));
+
+var server = serve(root)
+  .title('Duo')
+  .copy(true)
+  .entry('index.js')
+  .entry('index.css')
+  .body('index.html')
+  .hook(function (src, entry) {
+    if (entry.type === 'css') return myth(src);
+    return src;
+  });
 
 /**
  * Listen.
@@ -34,17 +39,3 @@ server.listen(port, function(){
   console.log('  just refresh the page to see what the changes look like!');
   console.log();
 });
-
-/**
- * Koa middleware to execute a `command`.
- *
- * @param {String} cmd
- * @return {Generator}
- */
-
-function exec(cmd) {
-  return function *(next) {
-    yield e(cmd);
-    yield next;
-  };
-}

--- a/package.json
+++ b/package.json
@@ -5,12 +5,9 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^0.5.1",
-    "co-exec": "^1.1.0",
     "duo": "~0.7.7",
+    "duo-serve": "^0.7.0",
     "handlebars": "^2.0.0-alpha.4",
-    "koa": "^0.8.2",
-    "koa-logger": "^1.2.2",
-    "koa-static": "^1.4.6",
     "metalsmith": "^0.9.0",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-permalinks": "^0.3.2",


### PR DESCRIPTION
I am proposing using duo-serve here since it's a dedicated tool for the job.

The current server runs `make build` for every single request. (even those unrelated to the build directly, doing a lot of extra work behind the scenes) This could be optimized of course, but I figured I would propose this here in the name of simplicity :)
